### PR TITLE
Fix #87 skip test with 7.2 (create_function is deprecated)

### DIFF
--- a/extension/tests/trace_002.phpt
+++ b/extension/tests/trace_002.phpt
@@ -1,5 +1,7 @@
 --TEST--
 Trace include, require, lambda, eval
+--SKIPIF--
+<?php (PHP_VERSION_ID < 70200) or die("skip PHP <= 7.2 only"); ?>
 --INI--
 trace.dotrace=1
 --FILE--


### PR DESCRIPTION
closure seems covered in tests/special_func_002.phpt
(else could be interesting to duplicate this test using a closure)
